### PR TITLE
[FIX] warnings occur when msgpack4s is added to other sbt projects using git repository

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,3 @@
-import bintray.Plugin.bintrayPublishSettings
-
 name := "msgpack4s"
 
 organization := "org.velvia"
@@ -25,8 +23,6 @@ lazy val playJson   = "com.typesafe.play" %% "play-json" % "2.4.1"
 libraryDependencies ++= Seq(rojomaJson % "provided",
                             json4s     % "provided",
                             playJson   % "provided")
-
-Seq(bintrayPublishSettings: _*)
 
 licenses += ("Apache-2.0", url("http://choosealicense.com/licenses/apache/"))
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,0 @@
-sbt.version=0.13.7

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,10 +1,1 @@
-resolvers += Resolver.url(
-  "bintray-sbt-plugin-releases",
-    url("http://dl.bintray.com/content/sbt/sbt-plugin-releases"))(
-        Resolver.ivyStylePatterns)
-
-addSbtPlugin("me.lessis" % "bintray-sbt" % "0.1.1")
-
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.1.12")
-
-addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.0")

--- a/src/org.velvia/MsgPackUtils.scala
+++ b/src/org.velvia/MsgPackUtils.scala
@@ -1,5 +1,6 @@
 package org.velvia
 
+import scala.language.implicitConversions
 import java.io.DataInputStream
 
 /**


### PR DESCRIPTION
Remove `bintray` related sbt configurations.

We don't use `bintray` and, don't need to publish our version.
So removed to make sbt stop complaining about `bintray credentials`.

Addtionally, to remove `implicitConversion` warning in `MsgPackUtils.scala`,
added `import scala.language.implicitConversions`
