### PR TITLE
Set scalaVersion to 2.11.7

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,9 +2,7 @@ name := "msgpack4s"
 
 organization := "org.velvia"
 
-scalaVersion := "2.10.4"
-
-crossScalaVersions := Seq("2.10.4", "2.11.5")
+scalaVersion := "2.11.7"
 
 unmanagedSourceDirectories in Compile <++= Seq(baseDirectory(_ / "src" )).join
 


### PR DESCRIPTION
## Problem

Migrate our main project 's scala version to `2.11.x`.
But sbt's `dependsOn` doesn't support **cross-building**

_Related Thread_: https://github.com/sbt/sbt/issues/1448
## Solution

Set scalaVersion to `2.11.7`.
Remove `crossScalaVersions`, because we don't need to publish this version.
## Result

Compatible with Scala `2.11.7`
