### PR TITLE
Compile jmh with Scala 2.11.7

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,8 +1,6 @@
 name := "msgpack4s"
 
-organization := "org.velvia"
-
-scalaVersion := "2.11.7"
+val commonSettings = Seq(scalaVersion := "2.11.7", organization := "org.velvia")
 
 unmanagedSourceDirectories in Compile <++= Seq(baseDirectory(_ / "src" )).join
 
@@ -24,10 +22,11 @@ libraryDependencies ++= Seq(rojomaJson % "provided",
 
 licenses += ("Apache-2.0", url("http://choosealicense.com/licenses/apache/"))
 
-lazy val msgpack4s = (project in file("."))
+lazy val msgpack4s = (project in file(".")).settings(commonSettings: _*)
 
 lazy val jmh = (project in file("jmh")).dependsOn(msgpack4s)
-                        .settings(jmhSettings:_*)
+                        .settings(commonSettings: _*)
+                        .settings(jmhSettings: _*)
                         .settings(libraryDependencies += rojomaJson)
                         .settings(libraryDependencies += json4s)
                         .settings(libraryDependencies += commonsIo)


### PR DESCRIPTION
## Problem

Project is not refreshed properly in IntelliJ IDEA 15, causing the error like this:

```
Error:Unresolved dependencies:
* org.velvia#msgpack4s_2.10;0.5.2-SNAPSHOT: not found

See complete log in /Users/e0en/Library/Logs/IdeaIC15/sbt.last.log
```

Here is the content of `sbt.last.log`.

```
Picked up JAVA_TOOL_OPTIONS: -Dfile.encoding=UTF-8
Java HotSpot(TM) 64-Bit Server VM warning: ignoring option MaxPermSize=384M; support was removed in 8.0
Getting org.scala-sbt sbt 0.13.9 ...
downloading https://repo.typesafe.com/typesafe/ivy-releases/org.scala-sbt/sbt/0.13.9/jars/sbt.jar ...
    [SUCCESSFUL ] org.scala-sbt#sbt;0.13.9!sbt.jar (6674ms)
downloading https://repo.typesafe.com/typesafe/ivy-releases/org.scala-sbt/main/0.13.9/jars/main.jar ...
    [SUCCESSFUL ] org.scala-sbt#main;0.13.9!main.jar (10928ms)
downloading https://repo.typesafe.com/typesafe/ivy-releases/org.scala-sbt/compiler-interface/0.13.9/jars/compiler-interface-bin.jar ...
    [SUCCESSFUL ] org.scala-sbt#compiler-interface;0.13.9!compiler-interface-bin.jar (8454ms)
downloading https://repo.typesafe.com/typesafe/ivy-releases/org.scala-sbt/compiler-interface/0.13.9/jars/compiler-interface-src.jar ...
    [SUCCESSFUL ] org.scala-sbt#compiler-interface;0.13.9!compiler-interface-src.jar (5696ms)
downloading https://repo.typesafe.com/typesafe/ivy-releases/org.scala-sbt/precompiled-2_8_2/0.13.9/jars/compiler-interface-bin.jar ...
    [SUCCESSFUL ] org.scala-sbt#precompiled-2_8_2;0.13.9!compiler-interface-bin.jar (10441ms)
downloading https://repo.typesafe.com/typesafe/ivy-releases/org.scala-sbt/precompiled-2_9_2/0.13.9/jars/compiler-interface-bin.jar ...
    [SUCCESSFUL ] org.scala-sbt#precompiled-2_9_2;0.13.9!compiler-interface-bin.jar (7066ms)
downloading https://repo.typesafe.com/typesafe/ivy-releases/org.scala-sbt/precompiled-2_9_3/0.13.9/jars/compiler-interface-bin.jar ...
    [SUCCESSFUL ] org.scala-sbt#precompiled-2_9_3;0.13.9!compiler-interface-bin.jar (7459ms)
downloading https://repo.typesafe.com/typesafe/ivy-releases/org.scala-sbt/actions/0.13.9/jars/actions.jar ...
    [SUCCESSFUL ] org.scala-sbt#actions;0.13.9!actions.jar (10659ms)
downloading https://repo.typesafe.com/typesafe/ivy-releases/org.scala-sbt/main-settings/0.13.9/jars/main-settings.jar ...
    [SUCCESSFUL ] org.scala-sbt#main-settings;0.13.9!main-settings.jar (11303ms)
downloading https://repo.typesafe.com/typesafe/ivy-releases/org.scala-sbt/interface/0.13.9/jars/interface.jar ...
    [SUCCESSFUL ] org.scala-sbt#interface;0.13.9!interface.jar (4890ms)
downloading https://repo.typesafe.com/typesafe/ivy-releases/org.scala-sbt/io/0.13.9/jars/io.jar ...
    [SUCCESSFUL ] org.scala-sbt#io;0.13.9!io.jar (8473ms)
downloading https://repo.typesafe.com/typesafe/ivy-releases/org.scala-sbt/ivy/0.13.9/jars/ivy.jar ...
    [SUCCESSFUL ] org.scala-sbt#ivy;0.13.9!ivy.jar (11460ms)
downloading https://repo.typesafe.com/typesafe/ivy-releases/org.scala-sbt/logging/0.13.9/jars/logging.jar ...
    [SUCCESSFUL ] org.scala-sbt#logging;0.13.9!logging.jar (7547ms)
downloading https://repo.typesafe.com/typesafe/ivy-releases/org.scala-sbt/logic/0.13.9/jars/logic.jar ...
    [SUCCESSFUL ] org.scala-sbt#logic;0.13.9!logic.jar (5341ms)
downloading https://repo.typesafe.com/typesafe/ivy-releases/org.scala-sbt/process/0.13.9/jars/process.jar ...
    [SUCCESSFUL ] org.scala-sbt#process;0.13.9!process.jar (5242ms)
downloading https://repo.typesafe.com/typesafe/ivy-releases/org.scala-sbt/run/0.13.9/jars/run.jar ...
    [SUCCESSFUL ] org.scala-sbt#run;0.13.9!run.jar (6314ms)
downloading https://repo.typesafe.com/typesafe/ivy-releases/org.scala-sbt/command/0.13.9/jars/command.jar ...
    [SUCCESSFUL ] org.scala-sbt#command;0.13.9!command.jar (8611ms)
downloading https://jcenter.bintray.com/org/scala-sbt/launcher-interface/1.0.0-M1/launcher-interface-1.0.0-M1.jar ...
    [SUCCESSFUL ] org.scala-sbt#launcher-interface;1.0.0-M1!launcher-interface.jar (1183ms)
downloading https://repo.typesafe.com/typesafe/ivy-releases/org.scala-sbt/classpath/0.13.9/jars/classpath.jar ...
    [SUCCESSFUL ] org.scala-sbt#classpath;0.13.9!classpath.jar (6722ms)
downloading https://repo.typesafe.com/typesafe/ivy-releases/org.scala-sbt/completion/0.13.9/jars/completion.jar ...
    [SUCCESSFUL ] org.scala-sbt#completion;0.13.9!completion.jar (9417ms)
downloading https://repo.typesafe.com/typesafe/ivy-releases/org.scala-sbt/api/0.13.9/jars/api.jar ...
    [SUCCESSFUL ] org.scala-sbt#api;0.13.9!api.jar (7568ms)
downloading https://repo.typesafe.com/typesafe/ivy-releases/org.scala-sbt/compiler-integration/0.13.9/jars/compiler-integration.jar ...
    [SUCCESSFUL ] org.scala-sbt#compiler-integration;0.13.9!compiler-integration.jar (6140ms)
downloading https://repo.typesafe.com/typesafe/ivy-releases/org.scala-sbt/compiler-ivy-integration/0.13.9/jars/compiler-ivy-integration.jar ...
    [SUCCESSFUL ] org.scala-sbt#compiler-ivy-integration;0.13.9!compiler-ivy-integration.jar (4964ms)
downloading https://repo.typesafe.com/typesafe/ivy-releases/org.scala-sbt/relation/0.13.9/jars/relation.jar ...
    [SUCCESSFUL ] org.scala-sbt#relation;0.13.9!relation.jar (6085ms)
downloading https://repo.typesafe.com/typesafe/ivy-releases/org.scala-sbt/task-system/0.13.9/jars/task-system.jar ...
    [SUCCESSFUL ] org.scala-sbt#task-system;0.13.9!task-system.jar (6016ms)
downloading https://repo.typesafe.com/typesafe/ivy-releases/org.scala-sbt/tasks/0.13.9/jars/tasks.jar ...
    [SUCCESSFUL ] org.scala-sbt#tasks;0.13.9!tasks.jar (5526ms)
downloading https://repo.typesafe.com/typesafe/ivy-releases/org.scala-sbt/tracking/0.13.9/jars/tracking.jar ...
    [SUCCESSFUL ] org.scala-sbt#tracking;0.13.9!tracking.jar (4737ms)
downloading https://repo.typesafe.com/typesafe/ivy-releases/org.scala-sbt/testing/0.13.9/jars/testing.jar ...
    [SUCCESSFUL ] org.scala-sbt#testing;0.13.9!testing.jar (5736ms)
downloading https://jcenter.bintray.com/org/scala-lang/scala-compiler/2.10.5/scala-compiler-2.10.5.jar ...
    [SUCCESSFUL ] org.scala-lang#scala-compiler;2.10.5!scala-compiler.jar (22199ms)
downloading https://repo.typesafe.com/typesafe/ivy-releases/org.scala-sbt/control/0.13.9/jars/control.jar ...
    [SUCCESSFUL ] org.scala-sbt#control;0.13.9!control.jar (5772ms)
downloading https://repo.typesafe.com/typesafe/ivy-releases/org.scala-sbt/collections/0.13.9/jars/collections.jar ...
    [SUCCESSFUL ] org.scala-sbt#collections;0.13.9!collections.jar (7767ms)
downloading https://repo.typesafe.com/typesafe/ivy-releases/org.scala-sbt/incremental-compiler/0.13.9/jars/incremental-compiler.jar ...
    [SUCCESSFUL ] org.scala-sbt#incremental-compiler;0.13.9!incremental-compiler.jar (7612ms)
downloading https://repo.typesafe.com/typesafe/ivy-releases/org.scala-sbt/compile/0.13.9/jars/compile.jar ...
    [SUCCESSFUL ] org.scala-sbt#compile;0.13.9!compile.jar (5494ms)
downloading https://repo.typesafe.com/typesafe/ivy-releases/org.scala-sbt/persist/0.13.9/jars/persist.jar ...
    [SUCCESSFUL ] org.scala-sbt#persist;0.13.9!persist.jar (5456ms)
downloading https://repo.typesafe.com/typesafe/ivy-releases/org.scala-sbt/classfile/0.13.9/jars/classfile.jar ...
    [SUCCESSFUL ] org.scala-sbt#classfile;0.13.9!classfile.jar (5446ms)
downloading https://repo.typesafe.com/typesafe/ivy-releases/org.scala-sbt/cross/0.13.9/jars/cross.jar ...
    [SUCCESSFUL ] org.scala-sbt#cross;0.13.9!cross.jar (4945ms)
downloading https://jcenter.bintray.com/org/scala-sbt/ivy/ivy/2.3.0-sbt-c5d1b95fdcc1e1007740ffbecf4eb07abc51ec93/ivy-2.3.0-sbt-c5d1b95fdcc1e1007740ffbecf4eb07abc51ec93.jar ...
    [SUCCESSFUL ] org.scala-sbt.ivy#ivy;2.3.0-sbt-c5d1b95fdcc1e1007740ffbecf4eb07abc51ec93!ivy.jar (3718ms)
downloading https://repo.typesafe.com/typesafe/ivy-releases/org.scala-sbt/cache/0.13.9/jars/cache.jar ...
    [SUCCESSFUL ] org.scala-sbt#cache;0.13.9!cache.jar (6128ms)
downloading https://repo.typesafe.com/typesafe/ivy-releases/org.scala-sbt/test-agent/0.13.9/jars/test-agent.jar ...
    [SUCCESSFUL ] org.scala-sbt#test-agent;0.13.9!test-agent.jar (6451ms)
downloading https://repo.typesafe.com/typesafe/ivy-releases/org.scala-sbt/apply-macro/0.13.9/jars/apply-macro.jar ...
    [SUCCESSFUL ] org.scala-sbt#apply-macro;0.13.9!apply-macro.jar (8340ms)
:: retrieving :: org.scala-sbt#boot-app
    confs: [default]
    52 artifacts copied, 0 already retrieved (17785kB/149ms)
Getting Scala 2.10.5 (for sbt)...
downloading https://jcenter.bintray.com/org/scala-lang/jline/2.10.5/jline-2.10.5.jar ...
    [SUCCESSFUL ] org.scala-lang#jline;2.10.5!jline.jar (1553ms)
:: retrieving :: org.scala-sbt#boot-scala
    confs: [default]
    5 artifacts copied, 0 already retrieved (24493kB/109ms)
[info] Loading project definition from /Users/e0en/Codes/msgpack4s/project
[info] Updating {file:/Users/e0en/Codes/msgpack4s/project/}msgpack4s-build...
[info] Resolving pl.project13.scala#sbt-jmh;0.1.12 ...
[info] Resolving org.openjdk.jmh#jmh-core;1.6.2 ...
[info] Resolving net.sf.jopt-simple#jopt-simple;4.6 ...
[info] Resolving org.apache.commons#commons-math3;3.2 ...
[info] Resolving org.openjdk.jmh#jmh-generator-bytecode;1.6.2 ...
[info] Resolving org.openjdk.jmh#jmh-generator-reflection;1.6.2 ...
[info] Resolving org.openjdk.jmh#jmh-generator-asm;1.6.2 ...
[info] Resolving org.ow2.asm#asm;5.0.3 ...
[info] Resolving org.scala-lang#scala-library;2.10.5 ...
[info] Resolving org.scala-sbt#sbt;0.13.9 ...
[info] Resolving org.scala-sbt#main;0.13.9 ...
[info] Resolving org.scala-sbt#actions;0.13.9 ...
[info] Resolving org.scala-sbt#classpath;0.13.9 ...
[info] Resolving org.scala-lang#scala-compiler;2.10.5 ...
[info] Resolving org.scala-lang#scala-reflect;2.10.5 ...
[info] Resolving org.scala-sbt#interface;0.13.9 ...
[info] Resolving org.scala-sbt#io;0.13.9 ...
[info] Resolving org.scala-sbt#control;0.13.9 ...
[info] Resolving org.scala-sbt#launcher-interface;1.0.0-M1 ...
[info] Resolving org.scala-sbt#completion;0.13.9 ...
[info] Resolving org.scala-sbt#collections;0.13.9 ...
[info] Resolving jline#jline;2.11 ...
[info] Resolving org.scala-sbt#api;0.13.9 ...
[info] Resolving org.scala-sbt#compiler-integration;0.13.9 ...
[info] Resolving org.scala-sbt#incremental-compiler;0.13.9 ...
[info] Resolving org.scala-sbt#logging;0.13.9 ...
[info] Resolving org.scala-sbt#process;0.13.9 ...
[info] Resolving org.scala-sbt#relation;0.13.9 ...
[info] Resolving org.scala-sbt#compile;0.13.9 ...
[info] Resolving org.scala-sbt#classfile;0.13.9 ...
[info] Resolving org.scala-sbt#persist;0.13.9 ...
[info] Resolving org.scala-tools.sbinary#sbinary_2.10;0.4.2 ...
[info] Resolving org.scala-sbt#compiler-ivy-integration;0.13.9 ...
[info] Resolving org.scala-sbt#ivy;0.13.9 ...
[info] Resolving org.scala-sbt#cross;0.13.9 ...
[info] Resolving org.scala-sbt.ivy#ivy;2.3.0-sbt-c5d1b95fdcc1e1007740ffbecf4eb07abc51ec93 ...
[info] Resolving com.jcraft#jsch;0.1.46 ...
[info] Resolving org.scala-sbt#serialization_2.10;0.1.1 ...
[info] Resolving org.scala-lang.modules#scala-pickling_2.10;0.10.0 ...
[info] Resolving org.scalamacros#quasiquotes_2.10;2.0.1 ...
[info] Resolving org.json4s#json4s-core_2.10;3.2.10 ...
[info] Resolving org.json4s#json4s-ast_2.10;3.2.10 ...
[info] Resolving com.thoughtworks.paranamer#paranamer;2.6 ...
[info] Resolving org.spire-math#jawn-parser_2.10;0.6.0 ...
[info] Resolving org.spire-math#json4s-support_2.10;0.6.0 ...
[info] Resolving org.scala-sbt#run;0.13.9 ...
[info] Resolving org.scala-sbt#task-system;0.13.9 ...
[info] Resolving org.scala-sbt#tasks;0.13.9 ...
[info] Resolving org.scala-sbt#tracking;0.13.9 ...
[info] Resolving org.scala-sbt#cache;0.13.9 ...
[info] Resolving org.scala-sbt#testing;0.13.9 ...
[info] Resolving org.scala-sbt#test-agent;0.13.9 ...
[info] Resolving org.scala-sbt#test-interface;1.0 ...
[info] Resolving org.scala-sbt#main-settings;0.13.9 ...
[info] Resolving org.scala-sbt#apply-macro;0.13.9 ...
[info] Resolving org.scala-sbt#command;0.13.9 ...
[info] Resolving org.scala-sbt#logic;0.13.9 ...
[info] Resolving org.scala-sbt#compiler-interface;0.13.9 ...
[info] Resolving org.scala-sbt#precompiled-2_8_2;0.13.9 ...
[info] Resolving org.scala-sbt#precompiled-2_9_2;0.13.9 ...
[info] Resolving org.scala-sbt#precompiled-2_9_3;0.13.9 ...
[info] Resolving org.scala-lang#jline;2.10.5 ...
[info] Resolving org.fusesource.jansi#jansi;1.4 ...
[info] Done updating.
[info] Set current project to msgpack4s (in build file:/Users/e0en/Codes/msgpack4s/)
> [info] Defining msgpack4s/*:shellPrompt
[info] The new value will be used by no settings or tasks.
[info] Reapplying settings...
[info] Set current project to msgpack4s (in build file:/Users/e0en/Codes/msgpack4s/)
[info] Defining msgpack4s/*:artifactPath
[info] The new value will be used by no settings or tasks.
[info] Reapplying settings...
[info] Set current project to msgpack4s (in build file:/Users/e0en/Codes/msgpack4s/)
[info] Defining msgpack4s/*:artifactClassifier
[info] The new value will be used by msgpack4s/compile:packageBin::artifact, msgpack4s/compile:packageDoc::artifact and 3 others.
[info]  Run `last` for details.
[info] Reapplying settings...
[info] Set current project to msgpack4s (in build file:/Users/e0en/Codes/msgpack4s/)
[info] Applying State transformations org.jetbrains.sbt.ReadProject from /Users/e0en/Library/Application Support/IdeaIC15/Scala/launcher/sbt-structure-0.13.jar
[info] Reading structure from /Users/e0en/Codes/msgpack4s
[info] Updating {file:/Users/e0en/Codes/msgpack4s/}msgpack4s...
[info] Resolving org.scala-lang#scala-library;2.11.7 ...
[info] Resolving org.scalatest#scalatest_2.11;2.2.0 ...
[info] Resolving org.scala-lang#scala-reflect;2.11.1 ...
[info] Resolving org.scala-lang.modules#scala-xml_2.11;1.0.1 ...
[info] Resolving org.mockito#mockito-all;1.9.0 ...
[info] Resolving com.rojoma#rojoma-json-v3_2.11;3.3.0 ...
[info] Resolving org.scala-lang#scala-library;2.11.6 ...
[info] Resolving org.scala-lang#scala-reflect;2.11.6 ...
[info] Resolving org.json4s#json4s-native_2.11;3.2.11 ...
[info] Resolving org.json4s#json4s-core_2.11;3.2.11 ...
[info] Resolving org.json4s#json4s-ast_2.11;3.2.11 ...
[info] Resolving com.thoughtworks.paranamer#paranamer;2.6 ...
[info] Resolving org.scala-lang#scalap;2.11.0 ...
[info] Resolving org.scala-lang#scala-compiler;2.11.0 ...
[info] Resolving org.scala-lang.modules#scala-parser-combinators_2.11;1.0.1 ...
[info] Resolving com.typesafe.play#play-json_2.11;2.4.1 ...
[info] Resolving com.typesafe.play#play-iteratees_2.11;2.4.1 ...
[info] Resolving org.scala-stm#scala-stm_2.11;0.7 ...
[info] Resolving com.typesafe#config;1.3.0 ...
[info] Resolving com.typesafe.play#play-functional_2.11;2.4.1 ...
[info] Resolving com.typesafe.play#play-datacommons_2.11;2.4.1 ...
[info] Resolving joda-time#joda-time;2.7 ...
[info] Resolving org.joda#joda-convert;1.7 ...
[info] Resolving com.fasterxml.jackson.core#jackson-core;2.5.4 ...
[info] Resolving com.fasterxml.jackson.core#jackson-annotations;2.5.4 ...
[info] Resolving com.fasterxml.jackson.core#jackson-databind;2.5.4 ...
[info] Resolving com.fasterxml.jackson.datatype#jackson-datatype-jdk8;2.5.4 ...
[info] Resolving com.fasterxml.jackson.datatype#jackson-datatype-jsr310;2.5.4 ...
[info] Resolving org.scala-lang#scala-compiler;2.11.7 ...
[info] Resolving org.scala-lang#scala-reflect;2.11.7 ...
[info] Resolving org.scala-lang.modules#scala-xml_2.11;1.0.4 ...
[info] Resolving org.scala-lang.modules#scala-parser-combinators_2.11;1.0.4 ...
[info] Resolving jline#jline;2.12.1 ...
[info] Done updating.
[info] Updating {file:/Users/e0en/Codes/msgpack4s/}jmh...
[info] Resolving org.scala-lang#scala-library;2.10.5 ...
[info] Resolving org.velvia#msgpack4s_2.10;0.5.2-SNAPSHOT ...
[info] Resolving org.velvia#msgpack4s_2.10;0.5.2-SNAPSHOT ...
[warn]  module not found: org.velvia#msgpack4s_2.10;0.5.2-SNAPSHOT
[warn] ==== local: tried
[warn]   /Users/e0en/.ivy2/local/org.velvia/msgpack4s_2.10/0.5.2-SNAPSHOT/ivys/ivy.xml
[warn] ==== jcenter: tried
[warn]   https://jcenter.bintray.com/org/velvia/msgpack4s_2.10/0.5.2-SNAPSHOT/msgpack4s_2.10-0.5.2-SNAPSHOT.pom
[warn] ==== public: tried
[warn]   https://repo1.maven.org/maven2/org/velvia/msgpack4s_2.10/0.5.2-SNAPSHOT/msgpack4s_2.10-0.5.2-SNAPSHOT.pom
[info] Resolving org.openjdk.jmh#jmh-core;1.6 ...
[info] Resolving net.sf.jopt-simple#jopt-simple;4.6 ...
[info] Resolving org.apache.commons#commons-math3;3.2 ...
[info] Resolving org.openjdk.jmh#jmh-generator-bytecode;1.6 ...
[info] Resolving org.openjdk.jmh#jmh-generator-reflection;1.6 ...
[info] Resolving org.openjdk.jmh#jmh-generator-asm;1.6 ...
[info] Resolving org.ow2.asm#asm;5.0.3 ...
[info] Resolving com.rojoma#rojoma-json-v3_2.10;3.3.0 ...
[info] Resolving org.scala-lang#scala-reflect;2.10.4 ...
[info] Resolving org.scalamacros#quasiquotes_2.10;2.0.1 ...
[info] Resolving org.json4s#json4s-native_2.10;3.2.11 ...
[info] Resolving org.json4s#json4s-core_2.10;3.2.11 ...
[info] Resolving org.json4s#json4s-ast_2.10;3.2.11 ...
[info] Resolving com.thoughtworks.paranamer#paranamer;2.6 ...
[info] Resolving org.scala-lang#scalap;2.10.0 ...
[info] Resolving org.scala-lang#scala-compiler;2.10.0 ...
[info] Resolving org.apache.commons#commons-io;1.3.2 ...
[info] Resolving commons-io#commons-io;1.3.2 ...
[info] Resolving org.scala-lang#scala-compiler;2.10.5 ...
[info] Resolving org.scala-lang#scala-reflect;2.10.5 ...
[info] Resolving org.scala-lang#jline;2.10.5 ...
[info] Resolving org.fusesource.jansi#jansi;1.4 ...
[warn]  ::::::::::::::::::::::::::::::::::::::::::::::
[warn]  ::          UNRESOLVED DEPENDENCIES         ::
[warn]  ::::::::::::::::::::::::::::::::::::::::::::::
[warn]  :: org.velvia#msgpack4s_2.10;0.5.2-SNAPSHOT: not found
[warn]  ::::::::::::::::::::::::::::::::::::::::::::::
[warn] 
[warn]  Note: Unresolved dependencies path:
[warn]      org.velvia:msgpack4s_2.10:0.5.2-SNAPSHOT
[warn]        +- jmh:jmh_2.10:0.5.2-SNAPSHOT
[trace] Stack trace suppressed: run 'last jmh/*:update' for the full output.
[error] (jmh/*:update) sbt.ResolveException: unresolved dependency: org.velvia#msgpack4s_2.10;0.5.2-SNAPSHOT: not found
sbt.ResolveException: unresolved dependency: org.velvia#msgpack4s_2.10;0.5.2-SNAPSHOT: not found
    at sbt.IvyActions$.sbt$IvyActions$$resolve(IvyActions.scala:294)
    at sbt.IvyActions$$anonfun$updateEither$1.apply(IvyActions.scala:191)
    at sbt.IvyActions$$anonfun$updateEither$1.apply(IvyActions.scala:168)
    at sbt.IvySbt$Module$$anonfun$withModule$1.apply(Ivy.scala:155)
    at sbt.IvySbt$Module$$anonfun$withModule$1.apply(Ivy.scala:155)
    at sbt.IvySbt$$anonfun$withIvy$1.apply(Ivy.scala:132)
    at sbt.IvySbt.sbt$IvySbt$$action$1(Ivy.scala:57)
    at sbt.IvySbt$$anon$4.call(Ivy.scala:65)
    at xsbt.boot.Locks$GlobalLock.withChannel$1(Locks.scala:93)
    at xsbt.boot.Locks$GlobalLock.xsbt$boot$Locks$GlobalLock$$withChannelRetries$1(Locks.scala:78)
    at xsbt.boot.Locks$GlobalLock$$anonfun$withFileLock$1.apply(Locks.scala:97)
    at xsbt.boot.Using$.withResource(Using.scala:10)
    at xsbt.boot.Using$.apply(Using.scala:9)
    at xsbt.boot.Locks$GlobalLock.ignoringDeadlockAvoided(Locks.scala:58)
    at xsbt.boot.Locks$GlobalLock.withLock(Locks.scala:48)
    at xsbt.boot.Locks$.apply0(Locks.scala:31)
    at xsbt.boot.Locks$.apply(Locks.scala:28)
    at sbt.IvySbt.withDefaultLogger(Ivy.scala:65)
    at sbt.IvySbt.withIvy(Ivy.scala:127)
    at sbt.IvySbt.withIvy(Ivy.scala:124)
    at sbt.IvySbt$Module.withModule(Ivy.scala:155)
    at sbt.IvyActions$.updateEither(IvyActions.scala:168)
    at sbt.Classpaths$$anonfun$sbt$Classpaths$$work$1$1.apply(Defaults.scala:1392)
    at sbt.Classpaths$$anonfun$sbt$Classpaths$$work$1$1.apply(Defaults.scala:1388)
    at sbt.Classpaths$$anonfun$doWork$1$1$$anonfun$90.apply(Defaults.scala:1422)
    at sbt.Classpaths$$anonfun$doWork$1$1$$anonfun$90.apply(Defaults.scala:1420)
    at sbt.Tracked$$anonfun$lastOutput$1.apply(Tracked.scala:37)
    at sbt.Classpaths$$anonfun$doWork$1$1.apply(Defaults.scala:1425)
    at sbt.Classpaths$$anonfun$doWork$1$1.apply(Defaults.scala:1419)
    at sbt.Tracked$$anonfun$inputChanged$1.apply(Tracked.scala:60)
    at sbt.Classpaths$.cachedUpdate(Defaults.scala:1442)
    at sbt.Classpaths$$anonfun$updateTask$1.apply(Defaults.scala:1371)
    at sbt.Classpaths$$anonfun$updateTask$1.apply(Defaults.scala:1325)
    at scala.Function1$$anonfun$compose$1.apply(Function1.scala:47)
    at sbt.$tilde$greater$$anonfun$$u2219$1.apply(TypeFunctions.scala:40)
    at sbt.std.Transform$$anon$4.work(System.scala:63)
    at sbt.Execute$$anonfun$submit$1$$anonfun$apply$1.apply(Execute.scala:226)
    at sbt.Execute$$anonfun$submit$1$$anonfun$apply$1.apply(Execute.scala:226)
    at sbt.ErrorHandling$.wideConvert(ErrorHandling.scala:17)
    at sbt.Execute.work(Execute.scala:235)
    at sbt.Execute$$anonfun$submit$1.apply(Execute.scala:226)
    at sbt.Execute$$anonfun$submit$1.apply(Execute.scala:226)
    at sbt.ConcurrentRestrictions$$anon$4$$anonfun$1.apply(ConcurrentRestrictions.scala:159)
    at sbt.CompletionService$$anon$2.call(CompletionService.scala:28)
    at java.util.concurrent.FutureTask.run(FutureTask.java:266)
    at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
    at java.util.concurrent.FutureTask.run(FutureTask.java:266)
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
    at java.lang.Thread.run(Thread.java:745)
[error] sbt.ResolveException: unresolved dependency: org.velvia#msgpack4s_2.10;0.5.2-SNAPSHOT: not found
[error] Use 'last' for the full log.
```
## Solution

Annotated scala version to project `jmh`.
## Result

The project updates & syncs & compiles well in IntelliJ with no errors.
